### PR TITLE
catch and fix pixel_dimensions overflow

### DIFF
--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -140,4 +140,5 @@ fuzz_target!(|data: &[u8]| {
     annexb_reader.start(&mut ctx);
     annexb_reader.push(&mut ctx, data);
     annexb_reader.end_units(&mut ctx);
+    ctx.sps().for_each(|sps| { let _ = sps.pixel_dimensions(); });
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,9 @@ impl<Ctx> Context<Ctx> {
             self.seq_param_sets[id.id() as usize].as_ref()
         }
     }
+    pub fn sps(&self) -> impl Iterator<Item = &nal::sps::SeqParameterSet> {
+        self.seq_param_sets.iter().filter_map(Option::as_ref)
+    }
     pub fn put_seq_param_set(&mut self, sps: nal::sps::SeqParameterSet) {
         let i = sps.seq_parameter_set_id.id() as usize;
         self.seq_param_sets[i] = Some(sps);
@@ -51,6 +54,9 @@ impl<Ctx> Context<Ctx> {
         } else {
             self.pic_param_sets[id.id() as usize].as_ref()
         }
+    }
+    pub fn pps(&self) -> impl Iterator<Item = &nal::pps::PicParameterSet> {
+        self.pic_param_sets.iter().filter_map(Option::as_ref)
     }
     pub fn put_pic_param_set(&mut self, pps: nal::pps::PicParameterSet) {
         let i = pps.pic_parameter_set_id.id() as usize;

--- a/src/nal/pps.rs
+++ b/src/nal/pps.rs
@@ -15,6 +15,7 @@ pub enum PpsError {
     UnknownSeqParamSetId(ParamSetId),
     BadPicParamSetId(ParamSetIdError),
     BadSeqParamSetId(ParamSetIdError),
+    ScalingMatrix(sps::ScalingMatrixError),
 }
 
 impl From<bitreader::BitReaderError> for PpsError {
@@ -156,9 +157,9 @@ impl PicScalingMatrix {
                 let seq_scaling_list_present_flag = r.read_bool()?;
                 if seq_scaling_list_present_flag {
                     if i < 6 {
-                        scaling_list4x4.push(sps::ScalingList::read(r, 16)?);
+                        scaling_list4x4.push(sps::ScalingList::read(r, 16).map_err(PpsError::ScalingMatrix)?);
                     } else {
-                        scaling_list8x8.push(sps::ScalingList::read(r, 64)?);
+                        scaling_list8x8.push(sps::ScalingList::read(r, 64).map_err(PpsError::ScalingMatrix)?);
                     }
                 }
             }

--- a/src/nal/sps.rs
+++ b/src/nal/sps.rs
@@ -906,7 +906,8 @@ impl SeqParameterSet {
     /// Helper to calculate the pixel-dimensions of the video image specified by this SPS, taking
     /// into account sample-format, interlacing and cropping.
     pub fn pixel_dimensions(&self) -> Result<(u32, u32), SpsError> {
-        let width = (self.pic_width_in_mbs_minus1 + 1) * 16;
+        let width = self.pic_width_in_mbs_minus1.checked_add(1).and_then(|w| w.checked_mul(16))
+            .ok_or_else(|| SpsError::FieldValueTooLarge { name:"pic_width_in_mbs_minus1", value: self.pic_width_in_mbs_minus1 })?;
         let mul = match self.frame_mbs_flags {
             FrameMbsFlags::Fields { .. } => 2,
             FrameMbsFlags::Frames => 1,

--- a/src/nal/sps.rs
+++ b/src/nal/sps.rs
@@ -389,6 +389,8 @@ pub enum PicOrderCntError {
     ReaderError(bitreader::BitReaderError),
     /// log2_max_pic_order_cnt_lsb_minus4 must be between 0 and 12
     Log2MaxPicOrderCntLsbMinus4OutOfRange(u32),
+    /// num_ref_frames_in_pic_order_cnt_cycle must be between 0 and 255
+    NumRefFramesInPicOrderCntCycleOutOfRange(u32),
 }
 
 impl From<bitreader::BitReaderError> for PicOrderCntError {
@@ -447,6 +449,9 @@ impl PicOrderCntType {
 
     fn read_offsets_for_ref_frame(r: &mut RbspBitReader<'_>) -> Result<Vec<i32>, PicOrderCntError> {
         let num_ref_frames_in_pic_order_cnt_cycle = r.read_ue()?;
+        if num_ref_frames_in_pic_order_cnt_cycle > 255 {
+            return Err(PicOrderCntError::NumRefFramesInPicOrderCntCycleOutOfRange(num_ref_frames_in_pic_order_cnt_cycle));
+        }
         let mut offsets = Vec::with_capacity(num_ref_frames_in_pic_order_cnt_cycle as usize);
         for _ in 0..num_ref_frames_in_pic_order_cnt_cycle {
             offsets.push(r.read_se()?);


### PR DESCRIPTION
I found this first by fuzzing my own crate that used this method, then added it to h264-reader's fuzz tests.