### PR TITLE
🪂 Expose some members of `PicParameterSetExtra`

### DIFF
--- a/src/nal/pps.rs
+++ b/src/nal/pps.rs
@@ -186,7 +186,7 @@ impl PicScalingMatrix {
 pub struct PicParameterSetExtra {
     pub transform_8x8_mode_flag: bool,
     pub pic_scaling_matrix: Option<PicScalingMatrix>,
-    second_chroma_qp_index_offset: i32,
+    pub second_chroma_qp_index_offset: i32,
 }
 impl PicParameterSetExtra {
     fn read<R: BitRead>(

--- a/src/nal/pps.rs
+++ b/src/nal/pps.rs
@@ -184,8 +184,8 @@ impl PicScalingMatrix {
 
 #[derive(Debug, Clone)]
 pub struct PicParameterSetExtra {
-    transform_8x8_mode_flag: bool,
-    pic_scaling_matrix: Option<PicScalingMatrix>,
+    pub transform_8x8_mode_flag: bool,
+    pub pic_scaling_matrix: Option<PicScalingMatrix>,
     second_chroma_qp_index_offset: i32,
 }
 impl PicParameterSetExtra {

--- a/src/nal/pps.rs
+++ b/src/nal/pps.rs
@@ -140,7 +140,7 @@ impl SliceGroup {
 }
 
 #[derive(Debug, Clone)]
-struct PicScalingMatrix {
+pub struct PicScalingMatrix {
     // TODO
 }
 impl PicScalingMatrix {


### PR DESCRIPTION
I need these publicly available for a project to fill out all the pps flags required