### PR TITLE
Allow borrowing the underlying reader for rbsp::ByteReader

### DIFF
--- a/src/rbsp.rs
+++ b/src/rbsp.rs
@@ -264,6 +264,15 @@ impl<R: std::io::BufRead + Clone> BitReader<R> {
     pub fn reader(&mut self) -> Option<&mut R> {
         self.reader.reader()
     }
+
+    /// Unwraps internal reader and disposes of BitReader.
+    ///
+    /// # Warning
+    ///
+    /// Any unread partial bits are discarded.
+    pub fn into_reader(self) -> R {
+        self.reader.into_reader()
+    }
 }
 
 impl<R: std::io::BufRead + Clone> BitRead for BitReader<R> {

--- a/src/rbsp.rs
+++ b/src/rbsp.rs
@@ -134,6 +134,11 @@ impl<R: BufRead> ByteReader<R> {
         }
         Ok(true)
     }
+
+    /// Borrows the underlying reader
+    pub fn reader(&mut self) -> &mut R {
+        &mut self.inner
+    }
 }
 impl<R: BufRead> Read for ByteReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {


### PR DESCRIPTION
This is useful, for example, to get the number of bytes consumed from the underlying readers after parsing a slice header.