### PR TITLE
`impl Debug for Context`; `decode_avcc` example

### DIFF
--- a/examples/decode_avcc.rs
+++ b/examples/decode_avcc.rs
@@ -1,0 +1,22 @@
+//! Creates a context from an encoded
+//! [`h264_reader::avc::AVCDecoderConfigurationRecord`] and prints it.
+
+use std::convert::TryFrom;
+
+use h264_reader::avcc::AvcDecoderConfigurationRecord;
+
+fn main() {
+    let path = {
+        let mut args = std::env::args_os();
+        if args.len() != 2 {
+            eprintln!("Usage: decode_avcc path/to/avcc");
+            std::process::exit(1);
+        }
+        args.nth(1).unwrap()
+    };
+
+    let raw = std::fs::read(path).unwrap();
+    let record = AvcDecoderConfigurationRecord::try_from(&raw[..]).unwrap();
+    let ctx = record.create_context().unwrap();
+    println!("{:#?}", &ctx);
+}


### PR DESCRIPTION
The new example is useful e.g. here:
https://github.com/scottlamb/moonfire-nvr/issues/302#issuecomment-1892796704

Use a private helper to represent param set maps that impls `Debug`.

Along the way, switch the representation to let the alloc grow as necessary, rather than pre-allocating 32 slots. In the common case when only SPS 0 and PPS 0 are filled, the `Vec` capacity seems to be size 4, which means the allocations are 4*232=928 bytes and 4*72=288 bytes rather than 32*232=7,424 bytes and 32*72=2,304 bytes, which seems like a worthwhile savings for no real effort.

I played with a `Box<[Option[T]]>` to have `Context` be 32 bytes rather than 48, but `resize_with` overallocates capacity, and then `into_boxed_slice` does an extra copy to undo that, and writing more code to avoid that felt like premature optimization.

I also considered an `[Option<Box<T>>; 32]` but having `Context` take 2*32*8=512 bytes on the stack struck me as potentially problematic.