### PR TITLE
Fix explicit assignment slice group parsing

### DIFF
--- a/src/nal/pps.rs
+++ b/src/nal/pps.rs
@@ -130,9 +130,9 @@ impl SliceGroup {
     ) -> Result<Vec<u32>, PpsError> {
         let pic_size_in_map_units_minus1 = r.read_ue("pic_size_in_map_units_minus1")?;
         // TODO: avoid any panics due to failed conversions
-        let size = ((1f64 + f64::from(pic_size_in_map_units_minus1)).log2()) as u32;
+        let size = ((1f64 + f64::from(num_slice_groups_minus1)).log2()) as u32;
         let mut run_length_minus1 = Vec::with_capacity(num_slice_groups_minus1 as usize + 1);
-        for _ in 0..num_slice_groups_minus1 + 1 {
+        for _ in 0..pic_size_in_map_units_minus1 + 1 {
             run_length_minus1.push(r.read_u32(size, "slice_group_id")?);
         }
         Ok(run_length_minus1)

--- a/src/nal/pps.rs
+++ b/src/nal/pps.rs
@@ -130,7 +130,7 @@ impl SliceGroup {
     ) -> Result<Vec<u32>, PpsError> {
         let pic_size_in_map_units_minus1 = r.read_ue("pic_size_in_map_units_minus1")?;
         // TODO: avoid any panics due to failed conversions
-        let size = ((1f64 + f64::from(num_slice_groups_minus1)).log2()) as u32;
+        let size = (1f64 + f64::from(num_slice_groups_minus1)).log2().ceil() as u32;
         let mut run_length_minus1 = Vec::with_capacity(num_slice_groups_minus1 as usize + 1);
         for _ in 0..pic_size_in_map_units_minus1 + 1 {
             run_length_minus1.push(r.read_u32(size, "slice_group_id")?);


### PR DESCRIPTION
Fix variable-name confusion error.

According to the spec, the two values `pic_size_in_map_units_minus1` and `num_slice_groups_minus1` should be used the other way around.  As pointed out by @wrv.

Fixes #57

Also, fix a nearby calculation which lacked `ceil()`.  The spec asks for `Ceil( Log2( num_slice_groups_minus1 + 1 ) )`