### PR TITLE
Parse scaling lists properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 *   Make some fields of `SliceType` public.
 
+### Added
+
+*   Parsing of scaling lists
+
 ## 0.7.0 - 2023-05-30
 
 ### Changed


### PR DESCRIPTION
Scaling lists were skipped previously, I implemented proper parsing, which was mostly coming up with the types to store them in.

I hope the API with const-sized arrays is ok, it seemed whoever implemented skipping the lists wanted to use `Vec`s initially. I found the generic const more appealing, but can change back to `Vec`s if needed.