### PR TITLE
Fix missing PR_BASE_SHA which was causing CI job failures

### DIFF
--- a/.github/workflows/pr-benchmark-upload-from-main.yml
+++ b/.github/workflows/pr-benchmark-upload-from-main.yml
@@ -34,6 +34,7 @@ jobs:
             let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
             core.exportVariable("PR_HEAD", prEvent.pull_request.head.ref);
             core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
+            core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
             core.exportVariable("PR_DEFAULT", prEvent.pull_request.base.repo.default_branch);
             core.exportVariable("PR_NUMBER", prEvent.number);
       - uses: bencherdev/bencher@main


### PR DESCRIPTION
Looks like this was missing from b700155.

Caused [failed jobs](https://github.com/dholroyd/h264-reader/actions/runs/12967209055/job/36168818413) with..
```
invalid value '' for '--start-point-hash <START_POINT_HASH>'
```